### PR TITLE
refactor: make flowjax optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ mpi = [
     "mpi4jax",
 ]
 
+flow = ["flowjax"]
+
 [project.urls]
 # Documentation = "https://github.com/microsoft/python-package-template/tree/main#readme"
 Source = "https://github.com/vallis/discovery"

--- a/src/discovery/flow.py
+++ b/src/discovery/flow.py
@@ -2,6 +2,7 @@ import time
 import collections.abc
 import typing
 PyTree = typing.Any
+from textwrap import dedent
 
 import numpy as np
 import matplotlib.pyplot as pp
@@ -12,8 +13,15 @@ import jax.numpy as jnp
 import equinox as eqx
 import optax
 
-import flowjax.distributions
-
+try:
+    import flowjax.distributions
+except ModuleNotFoundError:
+    err_msg = dedent(
+        """flowjax was not found! Install discovery with flowjax (discovery[flow]) or
+        add it manually to your environment.
+        """,
+    )
+    raise ModuleNotFoundError(err_msg) from None
 
 # modified from flowjax/train/losses.py
 # obsolete, use ElboLoss factory


### PR DESCRIPTION
This PR makes `flowjax` an optional dependency of `discovery`. Users can install `flowjax` with:

```sh
pip install discovery[flow]
```

(@vallis I was torn between "flow" and "flows", let me know what you prefer)

The following error is raised if a user tries to import `discovery.flow` but hasn't installed `flowjax`:

```python
>>> import discovery.flow
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dave/research/nanograv/codes/discovery/src/discovery/flow.py", line 24, in <module>
    raise ModuleNotFoundError(err_msg) from None
ModuleNotFoundError: flowjax was not found! Install discovery with flowjax (discovery[flow]) or
        add it manually to your environment.
```