### PR TITLE
change pure python sums to jax sums for variable construction of WN

### DIFF
--- a/src/discovery/signals.py
+++ b/src/discovery/signals.py
@@ -63,12 +63,12 @@ def makenoise_measurement(psr, noisedict={}, scale=1.0, tnequad=False):
         toaerrs, masks = matrix.jnparray(scale * psr.toaerrs), [matrix.jnparray(mask) for mask in masks]
         if tnequad:
             def getnoise(params):
-                return jnp.sum(jnp.array([mask * (params[efac]**2 * toaerrs**2 + 10.0**(2 * (logscale + params[log10_tnequad])))
-                        for mask, efac, log10_tnequad in zip(masks, efacs, log10_tnequads)]), axis=0)
+                return matrix.jnparray([mask * (params[efac]**2 * toaerrs**2 + 10.0**(2 * (logscale + params[log10_tnequad])))
+                        for mask, efac, log10_tnequad in zip(masks, efacs, log10_tnequads)]).sum(axis=0)
         else:
             def getnoise(params):
-                return jnp.sum(jnp.array([mask * params[efac]**2 * (toaerrs**2 + 10.0**(2 * (logscale + params[log10_t2equad])))
-                        for mask, efac, log10_t2equad in zip(masks, efacs, log10_t2equads)]), axis=0)
+                return matrix.jnparray([mask * params[efac]**2 * (toaerrs**2 + 10.0**(2 * (logscale + params[log10_t2equad])))
+                        for mask, efac, log10_t2equad in zip(masks, efacs, log10_t2equads)]).sum(axis=0)
         getnoise.params = params
 
         return matrix.NoiseMatrix1D_var(getnoise)
@@ -148,13 +148,13 @@ def makegp_ecorr(psr, noisedict={}, enterprise=False, scale=1.0):
     logscale = np.log10(scale)
 
     if all(par in noisedict for par in params):
-        phi = jnp.sum(jnp.array([10.0**(2 * (logscale + noisedict[log10_ecorr])) * pmask for (log10_ecorr, pmask) in zip(log10_ecorrs, pmasks)]), axis=0)
+        phi = matrix.jnparray([10.0**(2 * (logscale + noisedict[log10_ecorr])) * pmask for (log10_ecorr, pmask) in zip(log10_ecorrs, pmasks)]).sum(axis=0)
 
         return matrix.ConstantGP(matrix.NoiseMatrix1D_novar(phi), Umatall)
     else:
         pmasks = [matrix.jnparray(pmask) for pmask in pmasks]
         def getphi(params):
-            return jnp.sum(jnp.array([10.0**(2 * (logscale + params[log10_ecorr])) * pmask for (log10_ecorr, pmask) in zip(log10_ecorrs, pmasks)]), axis=0)
+            return matrix.jnparray([10.0**(2 * (logscale + params[log10_ecorr])) * pmask for (log10_ecorr, pmask) in zip(log10_ecorrs, pmasks)]).sum(axis=0)
         getphi.params = params
 
         return matrix.VariableGP(matrix.NoiseMatrix1D_var(getphi), Umatall)


### PR DESCRIPTION
Creation WN matrix creates masked arrays associated with each backend and then adds them all together. That sum was a pure python sum before, because previously this was called only once. But when it's called multiple times this is very slow and doesn't seem to parallelize in XLA.