### PR TITLE
feat: add solar wind dm gp

### DIFF
--- a/src/discovery/signals.py
+++ b/src/discovery/signals.py
@@ -686,7 +686,7 @@ def makedelay(psr, delay, common=[], name='delay'):
 
 # standard parameters t, pos, d;
 def makedelay_deterministic(psr, delay, name='deterministic'):
-    argspec = inspect.getfullargspec(prior)
+    argspec = inspect.getfullargspec(delay)
     argmap = [f'{name}_{arg}' + (f'({components})' if argspec.annotations.get(arg) == typing.Sequence else '')
               for arg in argspec.args if arg not in ['t', 'pos', 'd']]
 


### PR DESCRIPTION
Copying over from [enterprise extensions](https://github.com/nanograv/enterprise_extensions/tree/main/enterprise_extensions/chromatic/solar_wind.py).

Adds Fourier basis solar wind dm gp and time domain sw gp with a linear interpolation.

Bug fix (taken from Pat) for deterministic solar wind.
