### PR TITLE
Removed duplicated 'dm' in metadata

### DIFF
--- a/src/discovery/pulsar.py
+++ b/src/discovery/pulsar.py
@@ -57,7 +57,7 @@ class Pulsar:
     tensor_columns = ['planetssb']
     # flags are done separately
 
-    metadata = ['name', 'dm', 'dm', 'dmx', 'pdist', 'pos', 'phi', 'theta']
+    metadata = ['name', 'dm', 'dmx', 'pdist', 'pos', 'phi', 'theta']
 
     def __init__(self):
         pass


### PR DESCRIPTION
Seems there was a small typo in metadata in `pulsar.py`. I just removed the duplicate `dm` entry.