### PR TITLE
Match EFAC prior used in enterprise

### DIFF
--- a/src/discovery/prior.py
+++ b/src/discovery/prior.py
@@ -14,7 +14,7 @@ def uniform(par, a, b):
 
 
 priordict_standard = {
-    "(.*_)?efac": [0.9, 1.1],
+    "(.*_)?efac": [0.1, 10],
     "(.*_)?t2equad": [-8.5, -5],
     "(.*_)?tnequad": [-8.5, -5],
     "(.*_)?log10_ecorr": [-8.5, -5],


### PR DESCRIPTION
The usual EFAC prior is U[0.1, 10]. This PR changes the standard prior on efac parameters from U[0.9, 1.1] to the prior used elsewhere.