### PR TITLE
fix(solar.make_chromaticdelay): NaN's in gradient

### DIFF
--- a/src/discovery/solar.py
+++ b/src/discovery/solar.py
@@ -45,13 +45,95 @@ def chromaticdelay(toas, freqs, t0, log10_Amp, log10_tau, idx):
     return matrix.jnp.where(dt > 0.0, -1.0 * (10**log10_Amp) * matrix.jnp.exp(-dt / (10**log10_tau)) * invnormfreqs**idx, 0.0)
 
 def make_chromaticdelay(psr, idx=None):
-    """From enterprise_extensions: pre-calculate chromatic exponential-dip delay."""
+    """Create a closure function for calculating chromatic exponential-dip delay.
 
+    This function acts as a factory. It pre-calculates TOA
+    and frequency-dependent terms from a pulsar object and returns a new
+    function (`decay`). This returned function computes the time delay
+    induced by a chromatic exponential event for specific event parameters.
+
+    The closure mechanism works as follows: The inner function `decay` retains
+    access to the variables `toadays`, `invnormfreqs`, `ln_10`, and
+    `ln_invnormfreqs` calculated in the scope of `make_chromaticdelay`, even
+    after `make_chromaticdelay` has finished executing. If `idx` is provided
+    to `make_chromaticdelay`, it is also fixed for the returned `decay`
+    function using `functools.partial`.
+
+    Parameters
+    ----------
+    psr : discovery.Pulsar
+        Pulsar object.
+    idx : float, optional
+        The chromatic index defining the delay's radio-frequency dependence.
+        If `None` (default), the returned `decay` function will require `idx`
+        as an argument. If a float is provided, this value is fixed for the
+        returned `decay` function.
+
+    Returns
+    -------
+    Callable
+        A function `decay` that calculates the chromatic delay.
+        Its signature depends on whether `idx` was provided to
+        `make_chromaticdelay`:
+
+        - If `idx` was provided: `decay(t0, log10_Amp, log10_tau)`
+        - If `idx` was `None`: `decay(t0, log10_Amp, log10_tau, idx)`
+
+        The arguments for the returned `decay` function are:
+            - `t0` (float): The MJD of the exponential dip event.
+            - `log10_Amp` (float): Log10 of the amplitude of the signal (unitless).
+              The actual amplitude `A` is `10**log10_Amp`. The amplitude is
+              defined at the reference frequency (1400 MHz) and time `t0`.
+            - `log10_tau` (float): Log10 of the decay timescale `tau` (in days).
+              The actual timescale is `tau = 10**log10_tau`.
+            - `idx` (float, required only if `idx` was `None` in the outer function):
+              The chromatic index.
+
+        The `decay` function returns an array of delays (in seconds) corresponding
+        to each TOA/frequency pair in the `psr` object.
+
+    Notes
+    -----
+    Originally, this function was not written in log-space. However, it was
+    found that large negative numbers in the exponent (`-(t - t_0)/tau`) lead
+    to `NaN` values in the gradients of likelihoods that incorporate this delay.
+
+    Now, most of the computation is done in log-space with the intent of stabilizing
+    gradients. Also for frequencies less than the normalizing
+    frequency (1400 MHz), the exponent is pushed towards more positive values.
+    However, this is often not enough to handle all of the possible `NaN`
+    values, so we mask out any that remain.
+
+    """
     toadays, invnormfreqs = matrix.jnparray(psr.toas / const.day), matrix.jnparray(1400.0 / psr.freqs)
 
+    # Put quantities into log-space
+    ln_10 = matrix.jnp.log(10)
+    ln_invnormfreqs = matrix.jnp.log(invnormfreqs)
+
     def decay(t0, log10_Amp, log10_tau, idx):
+
+        # Note that the usage of `jax.numpy.where` allows for the TOAs to be unordered.
+        # We only need to store the differences here.
         dt = toadays - t0
-        return matrix.jnp.where(dt > 0.0, -1.0 * (10**log10_Amp) * matrix.jnp.exp(-dt / (10**log10_tau)) * invnormfreqs**idx, 0.0)
+
+        # Store this mask because we'll use it twice.
+        dt_mask = dt > 0.0
+
+        # Get the exponent for the exponential dip. Return 0 if the TOA is before the
+        # start time `t0`.
+        vals = matrix.jnp.where(
+            dt_mask,
+            ln_10 * log10_Amp - dt / (10**log10_tau) + idx * ln_invnormfreqs,
+            0.0,
+        )
+
+        # Filter out any `NaN`s. A few things were tried here (e.g. clipping), but
+        # they didn't handle the `NaN`s in the gradient. This, while brute force,
+        # does the trick.
+        vals = matrix.jnp.where(matrix.jnp.isnan(vals), 0.0, vals)
+
+        return matrix.jnp.where(dt_mask, -1.0 * matrix.jnp.exp(vals), vals)
 
     if idx is not None:
         decay = functools.partial(decay, idx=idx)


### PR DESCRIPTION
I found `NaN`'s coming from this function in the gradients of both single-pulsar and full-PTA likelihoods. For very large negative numbers in the exponent, the gradient wrt the timescale $$\tau$$ is  

```math
\propto \frac{-\Delta t}{\tau}  e^{\tfrac{-\Delta t}{\tau}},
```

where $\Delta t$ is the time after the start of the event.  $\Delta t$ can be very large, which creates a product of a very large negative number and a number very close to zero. This produces `NaN`'s (I double checked I was working in double precision).

My first attempt at fixing this was to rewrite the dip in the form

```math
10^{\log_{10}(A)} e^{-\Delta t / 10^{\tau}} f^{-\gamma} =  \textrm{exp}\left(\log_{10}(A)\ln{(10)} + -\Delta t / 10^{\tau}  + -\gamma\ln{f}\right ),
```

which I hoped would stabilize the computation. It also *can* push the exponent towards more positive values for $f <$ 1400 MHz. It fixes some cases, but $$\Delta t$$ can still become large enough to make `NaN`s. I then tried a few things like clipping, scaling, etc., but the solution that worked ended up being the most simple one.

I added a `jnp.where` to filter `NaN`'s out of the exponent. If someone has a more intelligent solution to this issue, I'd be happy to change this PR.

There's also an updated docstring included in this PR.