### PR TITLE
fix: Fix normal for transformed parameters to be mean 0, standard deviation 10

### DIFF
--- a/src/discovery/samplers/numpyro.py
+++ b/src/discovery/samplers/numpyro.py
@@ -15,7 +15,7 @@ def makemodel_transformed(mylogl, transform=prior.makelogtransform_uniform, prio
     parlen = sum(int(par[par.index('(')+1:par.index(')')]) if '(' in par else 1 for par in logx.params)
 
     def numpyro_model():
-        pars = numpyro.sample('pars', dist.Normal(-10,10).expand([parlen]))
+        pars = numpyro.sample('pars', dist.Normal(0, 10).expand([parlen]))
         logl = logx(pars)
 
         numpyro.factor('logl', logl)


### PR DESCRIPTION
The current implementation sets the normal to be mean -10, standard deviaton 10. We want mean 0, standard deviation 10.

Altnernatively, we could use the numpyro `ImproperUniform` distribution, I suppose (https://num.pyro.ai/en/stable/distributions.html#improperuniform)