### PR TITLE
fix: Fix single-backend bin and empty-epoch bugs in makegp_ecorr

### DIFF
--- a/src/discovery/signals.py
+++ b/src/discovery/signals.py
@@ -162,19 +162,36 @@ def makegp_ecorr(psr, noisedict={}, enterprise=False, scale=1.0, selection=selec
     backend_flags = selection(psr)
     backends = [b for b in sorted(set(backend_flags)) if b != '']
     masks = [np.array(backend_flags == backend) for backend in backends]
+
+    if len(np.unique(masks)) == 1:
+        # for those pulsar with only one backend
+        first_valid_bin = 0
+    else:
+        first_valid_bin = 1
+
     for backend, mask in zip(backends, masks):
         log10_ecorrs.append(f'{psr.name}_{backend}_log10_ecorr')
 
-        # TOAs that do not belong to this mask get index zero, which is ignored below.
-        # This will fail if there's only one mask that covers all TOAs
         bins = quantize(psr.toas * mask)
 
         if enterprise:
             # legacy accounting of degrees of freedom
-            uniques, counts = np.unique(quantize(psr.toas * mask), return_counts=True)
-            Umats.append(np.vstack([bins == i for i, cnt in zip(uniques[1:], counts[1:]) if cnt > 1]).T)
+            uniques, counts = np.unique(bins, return_counts=True)
+            epoch_masks = [bins == i for i, cnt in zip(
+                uniques[first_valid_bin:],
+                counts[first_valid_bin:]) if cnt > 1]
+
+            if epoch_masks:
+                U_backend = np.vstack(epoch_masks).T
+            else:
+                # if there is no ToAs observed at the same time
+                U_backend = np.zeros((len(bins), 0))
+
+            Umats.append(U_backend)
         else:
-            Umats.append(np.vstack([bins == i for i in range(1, bins.max() + 1)]).T)
+            Umats.append(np.vstack([bins == i for i in range(
+                first_valid_bin, bins.max() + 1)]).T)
+
     Umatall = np.hstack(Umats)
     params = log10_ecorrs
 


### PR DESCRIPTION
The PR is related to #99 
This PR fixes the single-backend bin and empty-epoch bugs in makegp_ecorr.

- the single-backend bin bugs has been mentioned in 
https://github.com/nanograv/discovery/blob/ebd7edb48e2440b0a7bf86deee204e0117380eed/src/discovery/signals.py#L168-L169
If we try to analyze the ecorr noise in the pulsar which has only one backend, the first backend will be discarded.
Therefore, we use
```
    if len(np.unique(masks)) == 1:
        # for those pulsar with only one backend
        first_valid_bin = 0
    else:
        first_valid_bin = 1
```
and
```
Umats.append(np.vstack([bins == i for i in range(Add commentMore actions
                first_valid_bin, bins.max() + 1)]).T)
```
to make sure that we have the correct bins.

- empty-epoch bugs
If there is no ToAs observed at the same time and we only consider about the bins that have more than two ToAs. It will arise an error. It has been mentioned #96 to modify how many ToAs we need to consider about. But, for now, we can solve it like
```
            uniques, counts = np.unique(bins, return_counts=True)Add commentMore actions
            epoch_masks = [bins == i for i, cnt in zip(
                uniques[first_valid_bin:],
                counts[first_valid_bin:]) if cnt > 1]

            if epoch_masks:
                U_backend = np.vstack(epoch_masks).T
            else:
                # if there is no ToAs observed at the same time
                U_backend = np.zeros((len(bins), 0))

            Umats.append(U_backend)
```
to make it aligned with the default setting in `enterprise`.

Closes #99 