### PR TITLE
fix(optimal statistic): corrects Q normalization

### DIFF
--- a/src/discovery/optimal.py
+++ b/src/discovery/optimal.py
@@ -79,7 +79,7 @@ class OS:
 
             orfs = orf(matrix.jnparray(self.angles))
             # note the 2 to get OS = x^T Q x
-            denom = 2.0 * matrix.jnp.sqrt(matrix.jnp.sum(orfs**2 * matrix.jnparray(bs)))
+            denom = 2.0 * matrix.jnp.sqrt(2 * matrix.jnp.sum(orfs**2 * matrix.jnparray(bs)))
 
             Q = matrix.jnpzeros((cnt, cnt))
 
@@ -130,7 +130,7 @@ class OS:
 
             orfs = orf(matrix.jnparray(self.angles))
             # note the 2 to get OS = x^T Q x
-            denom = 2.0 * matrix.jnp.sqrt(matrix.jnp.sum(orfs**2 * matrix.jnparray(bs)))
+            denom = 2.0 * matrix.jnp.sqrt(2 * matrix.jnp.sum(orfs**2 * matrix.jnparray(bs)))
 
             Bs = [sPhi[:, None] * A for A in As]   # B_i = diag(sPhi) @ A_i
 


### PR DESCRIPTION
Q's normalization was missing a factor of sqrt(2), which is a consequence of Isserlis' theorem applied to real-valued random variables.

**Also Note:** To calculate Q, **your likelihood must use variable ecorr and variable timing** (`variable=True`). Maybe we should add a check for this? @vallis can you double check me on this?

I discovered this issue by comparing the cdfs obtained using `gx2mat` and `Q`. I locally modified the `gx2cdf` method to accept a matrix instead of using `gx2mat` by default. Here are the results:

### Without the fix
Amat is the value calculated by `gx2mat`
<img width="640" height="480" alt="compare-q-amat-cdf" src="https://github.com/user-attachments/assets/66ea1bae-721b-4dcd-91ca-c062e1dd3197" />

### With the fix
Amat is the value calculated by `gx2mat`
<img width="640" height="480" alt="compare-q-amat-cdf-fixed" src="https://github.com/user-attachments/assets/9829086d-b1d8-4426-a3c5-78563990f3a4" />
