### PR TITLE
fix(globalgp_fftcov): add fourierbasis kwarg

### DIFF
--- a/src/discovery/signals.py
+++ b/src/discovery/signals.py
@@ -768,7 +768,7 @@ def makecommongp_fftcov(psrs, prior, components, T, t0=None, order=1, oversample
                                 fourierbasis=(make_timeinterpbasis(start_time=t0, order=order) if fourierbasis is None else fourierbasis),
                                 common=common, vector=vector, name=name)
 
-def makeglobalgp_fftcov(psrs, prior, orf, components, T, t0, order=1, oversample=3, fmax_factor=1, cutoff=1, name='fftcovGlobalGP'):
+def makeglobalgp_fftcov(psrs, prior, orf, components, T, t0, order=1, oversample=3, fmax_factor=1, cutoff=1, fourierbasis=None, name='fftcovGlobalGP'):
     return makeglobalgp_fourier(psrs, psd2cov(prior, components, T, oversample, fmax_factor, cutoff), orf, components, T,
                                 fourierbasis=(make_timeinterpbasis(start_time=t0, order=order) if fourierbasis is None else fourierbasis),
                                 name=name)


### PR DESCRIPTION
Add kwarg with `None` default. Fixes bug where the method would always use `discovery.signals.fourierbasis` due to missing kwarg.