### PR TITLE
feat: Add make_sample() function to WoodburyKernel_varNP and remove params …

### DIFF
--- a/src/discovery/matrix.py
+++ b/src/discovery/matrix.py
@@ -1123,6 +1123,21 @@ class WoodburyKernel_varNP(VariableKernel):
     def __init__(self, N_var, F, P_var):
         self.N_var, self.F, self.P_var = N_var, F, P_var
 
+    def make_sample(self):
+        N_sample = self.N_var.make_sample()
+        P_sample = self.P_var.make_sample()
+        F = jnparray(self.F)
+
+        def sample(key, params):
+            key, n = N_sample(key, params)
+            key, c = P_sample(key, params)
+
+            return key, n + jnp.dot(F, c)
+        
+        sample.params =  sorted(set(N_sample.params + P_sample.params))
+
+        return sample
+
     def make_kernelproduct_vary(self, y):
         y_var = y
 
@@ -1725,7 +1740,7 @@ class WoodburyKernel_varN(VariableKernel):
         self.Pinv, self.ldP = P.inv()
         self.params = N_var.params
 
-    def make_sample(self, params):
+    def make_sample(self):
         N_sample = self.N_var.make_sample()
         P_sample = self.P.make_sample()
         F = jnparray(self.F)


### PR DESCRIPTION
…from  make_sample() in WoodburyKernel_varN

This PR adds a `make_sample()` function to the `WoodburyKernel_varNP`. The issue arose when I was trying to follow the simulations.rst tutorial given within discovery. When running 
`params = ds.sample_uniform(sampler.params)`, I got error `AttributeError: 'WoodburyKernel_varNP' object has no attribute 'make_sample'`. 

Further, `make_sample(self, params)` in `WoodburyKernel_varN` takes in `params` argument which differs from all other `make_sample()` functions in `matrix.py`. This raises error `TypeError: WoodburyKernel_varN.make_sample() missing 1 required positional argument: 'params'`. This PR removes params from the argument of `make_params `in `WoodburyKernel_varN`.

After changing these two, the simulation code is running successfully. 

Please let me know if any modifications are necessary.
