### PR TITLE
fix(optimal): use adaptive ridge for Cholesky stability

### DIFF
--- a/src/discovery/optimal.py
+++ b/src/discovery/optimal.py
@@ -26,30 +26,41 @@ def make2d(array):
     return matrix.jnp.diag(array) if array.ndim == 1 else array
 
 
-def schur_cholesky(Pinv, FFt, FTt, TTt):
-    """Cholesky factor ``A`` (with ``S = A @ A.T``) of the GW-space Schur complement
+def ridge_cholesky(Pinv, FFt, FTt, TTt):
+    """Cholesky factor ``A`` (``S = A @ A.T``) and the raw matrix ``S`` of the
+    GW-space matrix
 
         S = TTt - FTt.T @ (diag(Pinv) + FFt)^-1 @ FTt
           = G̃.T @ (I + F̃ B F̃.T)^-1 @ G̃          (B = diag(1/Pinv))
 
-    computed as the trailing block of the Cholesky of the joint matrix
+    The GW Fourier basis lies inside the red-noise span (its frequencies are a
+    subset of the red-noise frequencies on the same baseline), so ``S`` is the
+    difference of two large, nearly equal PSD matrices. For high-precision
+    pulsars its condition number runs past float64 and several eigenvalues come
+    out genuinely negative (e.g. J0437-4715: min eig ~ -19, cond ~ 1e15). An
+    adaptive ridge -- lift the smallest eigenvalue just past zero -- is required
+    before the Cholesky.
 
-        J = [[diag(Pinv) + FFt, FTt],
-             [FTt.T,            TTt]]
+    NB: a plain Cholesky-Schur factorization is *not* sufficient here. We tried
+    reading ``A`` off the Cholesky of the joint matrix [[diag(Pinv)+FFt, FTt],
+    [FTt.T, TTt]] to avoid forming the difference; that is exact in real
+    arithmetic but ``jnp.linalg.cholesky`` returns NaN (no exception) on the
+    numerically indefinite blocks, silently poisoning Q / gx2cdf for ~half the
+    NANOGrav-15 pulsars. See dev_architectures/os_memory_improvements/.
 
-    rather than by forming the difference ``TTt - (...)`` explicitly. The GW
-    Fourier basis lies inside the red-noise span (its frequencies are a subset
-    of the red-noise frequencies on the same baseline), so that difference is
-    between two large, nearly equal PSD matrices and cancels catastrophically,
-    losing positive-definiteness -- which is what the old ``1e-10 tr(S)/n``
-    ridge was patching. The Schur complement read off a Cholesky factor is PSD
-    by construction (it equals ``L22 @ L22.T``), so no ridge is needed and the
-    factor ``A = L22`` is obtained directly.
+    The raw (unridged) ``S`` is returned for the pairwise normalization ``bs``.
     """
-    mF = FFt.shape[0]
-    J = matrix.jnp.block([[matrix.jnp.diag(Pinv) + FFt, FTt],
-                          [FTt.T,                        TTt]])
-    return matrix.jnp.linalg.cholesky(J)[mF:, mF:]
+    c = matrix.jsp.linalg.cho_factor(matrix.jnp.diag(Pinv) + FFt)
+    S = TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt)
+    S = 0.5 * (S + S.T)  # enforce symmetry
+
+    # add only what is needed to make the smallest eigenvalue positive
+    eigs = matrix.jnp.linalg.eigvalsh(S)
+    ridge = (matrix.jnp.maximum(0.0, -matrix.jnp.min(eigs))
+             + 1e-12 * matrix.jnp.maximum(matrix.jnp.max(matrix.jnp.abs(eigs)), 1.0))
+
+    A = matrix.jnp.linalg.cholesky(S + ridge * matrix.jnp.eye(S.shape[0]))
+    return A, S
 
 class OS:
     def __init__(self, gbl):
@@ -93,11 +104,11 @@ class OS:
         def get_Q(params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            # S = G̃.T (I + F̃ B F̃.T)^-1 G̃ via the Schur complement of the joint
-            # Cholesky -> manifestly PSD, no ridge needed (see schur_cholesky)
-            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
-                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
-            Ss = [A @ A.T for A in As]
+            # S = G̃.T (I + F̃ B F̃.T)^-1 G̃; genuinely indefinite for
+            # high-precision pulsars, factored with an adaptive ridge (see
+            # ridge_cholesky). bs uses the raw (unridged) S.
+            As, Ss = zip(*[ridge_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                           for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)])
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             # Ds are symmetric, so tr(Ds[i] @ Ds[j]) == sum(Ds[i] * Ds[j]) (O(m^2), no m x m temporary)
@@ -144,9 +155,8 @@ class OS:
         def get_opQ(params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
-                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
-            Ss = [A @ A.T for A in As]
+            As, Ss = zip(*[ridge_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                           for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)])
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -195,9 +205,8 @@ class OS:
         def get_sample(key, params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
-                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
-            Ss = [A @ A.T for A in As]
+            As, Ss = zip(*[ridge_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                           for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)])
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -232,11 +241,10 @@ class OS:
         Fts = [LNm[:,None] * Fmat for LNm, Fmat in zip(LNms, Fmats)]
         Tts = [LNm[:,None] * Tmat for LNm, Tmat in zip(LNms, Tmats)] # this is GW-only
 
-        # S = G̃.T (I + F̃ B F̃.T)^-1 G̃ via the Schur complement of the joint
-        # Cholesky -> manifestly PSD, no ridge needed (see schur_cholesky)
-        As = [schur_cholesky(1.0 / Pmat, Ft.T @ Ft, Ft.T @ Tt, Tt.T @ Tt)
-              for Pmat, Ft, Tt in zip(Pmats, Fts, Tts)]
-        Ss = [A @ A.T for A in As]
+        # S = G̃.T (I + F̃ B F̃.T)^-1 G̃; genuinely indefinite for high-precision
+        # pulsars, factored with an adaptive ridge (see ridge_cholesky)
+        As, Ss = zip(*[ridge_cholesky(1.0 / Pmat, Ft.T @ Ft, Ft.T @ Tt, Tt.T @ Tt)
+                       for Pmat, Ft, Tt in zip(Pmats, Fts, Tts)])
 
         Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
         bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -482,6 +490,7 @@ class OS:
         return eig2cdf(osxs, eigx, cutoff=cutoff, limit=limit, epsabs=epsabs)
 
 
+# @jax.jit
 @jax.jit
 def imhof(u, x, eigs):
     theta = 0.5 * matrix.jnp.sum(matrix.jnp.arctan(eigs * u), axis=0) - 0.5 * x * u

--- a/src/discovery/optimal.py
+++ b/src/discovery/optimal.py
@@ -25,6 +25,32 @@ def monopole_orfa(z):
 def make2d(array):
     return matrix.jnp.diag(array) if array.ndim == 1 else array
 
+
+def schur_cholesky(Pinv, FFt, FTt, TTt):
+    """Cholesky factor ``A`` (with ``S = A @ A.T``) of the GW-space Schur complement
+
+        S = TTt - FTt.T @ (diag(Pinv) + FFt)^-1 @ FTt
+          = G̃.T @ (I + F̃ B F̃.T)^-1 @ G̃          (B = diag(1/Pinv))
+
+    computed as the trailing block of the Cholesky of the joint matrix
+
+        J = [[diag(Pinv) + FFt, FTt],
+             [FTt.T,            TTt]]
+
+    rather than by forming the difference ``TTt - (...)`` explicitly. The GW
+    Fourier basis lies inside the red-noise span (its frequencies are a subset
+    of the red-noise frequencies on the same baseline), so that difference is
+    between two large, nearly equal PSD matrices and cancels catastrophically,
+    losing positive-definiteness -- which is what the old ``1e-10 tr(S)/n``
+    ridge was patching. The Schur complement read off a Cholesky factor is PSD
+    by construction (it equals ``L22 @ L22.T``), so no ridge is needed and the
+    factor ``A = L22`` is obtained directly.
+    """
+    mF = FFt.shape[0]
+    J = matrix.jnp.block([[matrix.jnp.diag(Pinv) + FFt, FTt],
+                          [FTt.T,                        TTt]])
+    return matrix.jnp.linalg.cholesky(J)[mF:, mF:]
+
 class OS:
     def __init__(self, gbl):
         self.psls = gbl.psls
@@ -67,23 +93,11 @@ class OS:
         def get_Q(params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1.0 / Pvar(params)) + FFt) for Pvar, FFt in zip(Pvars, FFts)]
-            Ss = [TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt) for c, TTt, FTt in zip(cs, TTts, FTts)]
-
-            # adaptively ridge-regularize each S so its Cholesky is well defined:
-            # add only what is needed to make the smallest eigenvalue positive
-            As = []
-            for S in Ss:
-                S = 0.5 * (S + S.T)  # enforce symmetry
-
-                eigs = matrix.jnp.linalg.eigvalsh(S)
-                min_eig = matrix.jnp.min(eigs)
-                max_eig = matrix.jnp.max(matrix.jnp.abs(eigs))
-
-                eps = 1e-12 * matrix.jnp.maximum(max_eig, 1.0)
-                ridge = matrix.jnp.maximum(0.0, -min_eig) + eps
-
-                As.append(matrix.jnp.linalg.cholesky(S + ridge * matrix.jnp.eye(S.shape[0])))
+            # S = G̃.T (I + F̃ B F̃.T)^-1 G̃ via the Schur complement of the joint
+            # Cholesky -> manifestly PSD, no ridge needed (see schur_cholesky)
+            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
+            Ss = [A @ A.T for A in As]
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             # Ds are symmetric, so tr(Ds[i] @ Ds[j]) == sum(Ds[i] * Ds[j]) (O(m^2), no m x m temporary)
@@ -130,12 +144,9 @@ class OS:
         def get_opQ(params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1.0 / Pvar(params)) + FFt) for Pvar, FFt in zip(Pvars, FFts)]
-            Ss = [TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt) for c, TTt, FTt in zip(cs, TTts, FTts)]
-
-            Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
-            As = [matrix.jnp.linalg.cholesky(S + (1e-10 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
-                for S in Ss]
+            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
+            Ss = [A @ A.T for A in As]
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -184,13 +195,9 @@ class OS:
         def get_sample(key, params, orf=hd_orfa):
             sPhi = matrix.jnp.sqrt(Phivar(params))
 
-            # TO DO: should probably close on Ft.T @ Ft, Tt.T @ Tt, and Tt.T @ Ft (and Ft.T @ Tt) rather than on Fts and Tts
-            cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1.0 / Pvar(params)) + FFt) for Pvar, FFt in zip(Pvars, FFts)]
-            Ss = [TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt) for c, TTt, FTt in zip(cs, TTts, FTts)]
-
-            Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
-            As = [matrix.jnp.linalg.cholesky(S + (1e-10 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
-                  for S in Ss]
+            As = [schur_cholesky(1.0 / Pvar(params), FFt, FTt, TTt)
+                  for Pvar, FFt, FTt, TTt in zip(Pvars, FFts, FTts, TTts)]
+            Ss = [A @ A.T for A in As]
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -225,26 +232,11 @@ class OS:
         Fts = [LNm[:,None] * Fmat for LNm, Fmat in zip(LNms, Fmats)]
         Tts = [LNm[:,None] * Tmat for LNm, Tmat in zip(LNms, Tmats)] # this is GW-only
 
-        cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1/Pmat) + Ft.T @ Ft) for Pmat, Ft in zip(Pmats, Fts)]
-        Xs = [Tt - Ft @ matrix.jsp.linalg.cho_solve(c, Ft.T @ Tt) for c, Ft, Tt in zip(cs, Fts, Tts)]
-
-        Ss = [Tt.T @ X for Tt, X in zip(Tts, Xs)]
-
-        # alternative formulation (numerically unstable?):
-        # R = chol(Pmat^-1 + Ft.T @ Ft)
-        # Y = R^-1 @ Ft.T @ Tt
-        # S = Tt.T @ Tt - Y.T @ Y
-        #
-        # Rs = [matrix.jnp.linalg.cholesky(matrix.jnp.diag(1/Pmat) + Ft.T @ Ft, upper=True) for Pmat, Ft in zip(Pmats, Fts)]
-        # Ys = [matrix.jsp.linalg.solve_triangular(R, Ft.T @ Tt, lower=False) for R, Ft, Tt in zip(Rs, Fts, Tts)]
-        # Ss = [Tt.T @ Tt - Y.T @ Y for Tt, Y in zip(Tts, Ys)]
-
-        # with ridge regularization; the simple estimate based on the trace seems fine
-        # a more precise possibility is eps = matrix.jnp.maximum(0.0, -matrix.jnp.linalg.eigvalsh(S).min())
-        #                                     + 1e-10 * matrix.jnp.trace(S) / S.shape[0]
-        Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
-        As = [matrix.jnp.linalg.cholesky(S + (1e-10 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
-              for S in Ss]
+        # S = G̃.T (I + F̃ B F̃.T)^-1 G̃ via the Schur complement of the joint
+        # Cholesky -> manifestly PSD, no ridge needed (see schur_cholesky)
+        As = [schur_cholesky(1.0 / Pmat, Ft.T @ Ft, Ft.T @ Tt, Tt.T @ Tt)
+              for Pmat, Ft, Tt in zip(Pmats, Fts, Tts)]
+        Ss = [A @ A.T for A in As]
 
         Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
         bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
@@ -436,7 +428,7 @@ class OS:
             N = getN(params)
             ks = [k(params) for k in kernelsolves]
 
-            if sN.ndim == 2:
+            if N.ndim == 2:
                 raise NotImplementedError("Complex rhosigma not defined for 2D Phi.")
 
             sN = matrix.jnp.sqrt(N)
@@ -495,7 +487,10 @@ def imhof(u, x, eigs):
     theta = 0.5 * matrix.jnp.sum(matrix.jnp.arctan(eigs * u), axis=0) - 0.5 * x * u
     rho = matrix.jnp.prod((1.0 + (eigs * u)**2)**0.25, axis=0)
 
-    return matrix.jnp.sin(theta) / (u * rho)
+    # the integrand has a removable 0/0 singularity at u=0 with finite limit
+    # ½(Σλ - x); quadax may sample the lower endpoint, so return the limit there
+    limit = 0.5 * (matrix.jnp.sum(eigs, axis=0) - x)
+    return matrix.jnp.where(u == 0.0, limit, matrix.jnp.sin(theta) / (u * rho))
 
 def eig2cdf(osxs, eigs, cutoff=1e-6, limit=100, epsabs=1e-6):
     # cutoff by number of eigenvalues is more friendly to jitted imhof

--- a/src/discovery/optimal.py
+++ b/src/discovery/optimal.py
@@ -1,7 +1,7 @@
 import functools
 
 import numpy as np
-import scipy.integrate
+import quadax
 
 from . import matrix
 from . import signals
@@ -70,36 +70,24 @@ class OS:
             cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1.0 / Pvar(params)) + FFt) for Pvar, FFt in zip(Pvars, FFts)]
             Ss = [TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt) for c, TTt, FTt in zip(cs, TTts, FTts)]
 
-            # Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
-            # As = [matrix.jnp.linalg.cholesky(S + (1e-6 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
-            #     for S in Ss]
-
-            # loop to make matrix positive definite  
+            # adaptively ridge-regularize each S so its Cholesky is well defined:
+            # add only what is needed to make the smallest eigenvalue positive
             As = []
-            ridge_values = []
-            for k, S in enumerate(Ss):
+            for S in Ss:
                 S = 0.5 * (S + S.T)  # enforce symmetry
 
                 eigs = matrix.jnp.linalg.eigvalsh(S)
                 min_eig = matrix.jnp.min(eigs)
                 max_eig = matrix.jnp.max(matrix.jnp.abs(eigs))
 
-                # Safety scale
                 eps = 1e-12 * matrix.jnp.maximum(max_eig, 1.0)
-
-                # Add only what is needed to make the smallest eigenvalue positive
                 ridge = matrix.jnp.maximum(0.0, -min_eig) + eps
 
-                S_reg = S + ridge * matrix.jnp.eye(S.shape[0])
-
-                A = matrix.jnp.linalg.cholesky(S_reg)
-
-                As.append(A)
-                ridge_values.append(ridge)
-    
+                As.append(matrix.jnp.linalg.cholesky(S + ridge * matrix.jnp.eye(S.shape[0])))
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
-            bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
+            # Ds are symmetric, so tr(Ds[i] @ Ds[j]) == sum(Ds[i] * Ds[j]) (O(m^2), no m x m temporary)
+            bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]
 
             orfs = orf(matrix.jnparray(self.angles))
             # note the 2 to get OS = x^T Q x
@@ -150,7 +138,7 @@ class OS:
                 for S in Ss]
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
-            bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
+            bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
 
             orfs = orf(matrix.jnparray(self.angles))
             # note the 2 to get OS = x^T Q x
@@ -205,7 +193,7 @@ class OS:
                   for S in Ss]
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
-            bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
+            bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
 
             xs = matrix.jnpnormal(key, cnt)
             uks = [sPhi * (A @ xs[ind]) for A, ind in zip(As, inds)]
@@ -259,7 +247,7 @@ class OS:
               for S in Ss]
 
         Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
-        bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
+        bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
 
         inds, cnt = [], 0
         for A in As:
@@ -303,7 +291,7 @@ class OS:
         PsTts = [sPhi[:,matrix.jnp.newaxis] * Tmat.T for Tmat in Tmats]
 
         Ds = [sPhi[:,matrix.jnp.newaxis] * TtKmT * sPhi[matrix.jnp.newaxis,:] for TtKmT in TtKmTs]
-        bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
+        bs = [matrix.jnp.sum(Ds[i] * Ds[j]) for (i,j) in self.pairs]  # Ds symmetric: tr(A@B)==sum(A*B)
 
         cnt, iNs, iPs = 0, [], []
         for Nmat in Nmats:
@@ -366,7 +354,7 @@ class OS:
                 ts = [matrix.jnp.dot(sN * ks[i][0], sN * ks[j][0]) for (i,j) in pairs]
                 ds = [sN[:,matrix.jnp.newaxis] * k[1] * sN[matrix.jnp.newaxis,:] for k in ks]
 
-                bs = [matrix.jnp.trace(ds[i] @ ds[j]) for (i,j) in pairs]
+                bs = [matrix.jnp.sum(ds[i] * ds[j]) for (i,j) in pairs]  # ds symmetric: tr(A@B)==sum(A*B)
             else:
                 U = matrix.jnp.linalg.cholesky(N, upper=True) # N = U^T U, so y = U^T x
 
@@ -374,7 +362,7 @@ class OS:
                 ds = [U @ k[1] @ U.T for k in ks]
 
                 ts = [matrix.jnp.dot(uks[i], uks[j].T) for (i,j) in pairs]
-                bs = [matrix.jnp.trace(ds[i] @ ds[j]) for (i,j) in pairs]
+                bs = [matrix.jnp.sum(ds[i] * ds[j]) for (i,j) in pairs]  # ds symmetric: tr(A@B)==sum(A*B)
 
                 # slower:
                 # ts = [matrix.jnp.dot(U @ ks[i][0], U @ ks[j][0]) for (i,j) in pairs]
@@ -457,7 +445,7 @@ class OS:
             ts = [tsf[i] * matrix.jnp.conj(tsf[j]) for (i,j) in pairs]
 
             ds = [sN[:,matrix.jnp.newaxis] * k[1] * sN[matrix.jnp.newaxis,:] for k in ks]
-            bs = [matrix.jnp.trace(ds[i] @ ds[j]) for (i,j) in pairs]
+            bs = [matrix.jnp.sum(ds[i] * ds[j]) for (i,j) in pairs]  # ds symmetric: tr(A@B)==sum(A*B)
 
             # can't use matrix.jnparray or complex will be downcast
             return (matrix.jnparray(ts) / matrix.jnparray(bs)[:,matrix.jnp.newaxis],
@@ -511,8 +499,13 @@ def imhof(u, x, eigs):
 
 def eig2cdf(osxs, eigs, cutoff=1e-6, limit=100, epsabs=1e-6):
     # cutoff by number of eigenvalues is more friendly to jitted imhof
-    eigs = eigs[:cutoff] if cutoff > 1 else eigs[matrix.jnp.abs(eigs) > cutoff* matrix.jnp.abs(eigs).max()]
+    eigs = eigs[:cutoff] if cutoff > 1 else eigs[matrix.jnp.abs(eigs) > cutoff * matrix.jnp.abs(eigs).max()]
 
-    # jax.scipy.integrate is mostly not implemented. Could try quadax
-    return np.array([0.5 - scipy.integrate.quad(lambda u: float(imhof(u, osx, eigs)),
-                                                0, np.inf, limit=limit, epsabs=epsabs)[0] / np.pi for osx in osxs])
+    # quadax.quadgk is a JAX-transformable analog of scipy.integrate.quad,
+    # so we can vmap over osxs and keep everything in jax
+    def cdf(osx):
+        integral = quadax.quadgk(imhof, [0.0, matrix.jnp.inf], args=(osx, eigs),
+                                 epsabs=epsabs, max_ninter=limit)[0]
+        return 0.5 - integral / matrix.jnp.pi
+
+    return jax.vmap(cdf)(matrix.jnparray(osxs))

--- a/src/discovery/optimal.py
+++ b/src/discovery/optimal.py
@@ -70,9 +70,33 @@ class OS:
             cs = [matrix.jsp.linalg.cho_factor(matrix.jnp.diag(1.0 / Pvar(params)) + FFt) for Pvar, FFt in zip(Pvars, FFts)]
             Ss = [TTt - FTt.T @ matrix.jsp.linalg.cho_solve(c, FTt) for c, TTt, FTt in zip(cs, TTts, FTts)]
 
-            Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
-            As = [matrix.jnp.linalg.cholesky(S + (1e-10 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
-                for S in Ss]
+            # Ss = [0.5 * (S + S.T) for S in Ss]  # ensure symmetry
+            # As = [matrix.jnp.linalg.cholesky(S + (1e-6 * matrix.jnp.trace(S) / S.shape[0]) * matrix.jnp.eye(S.shape[0]))
+            #     for S in Ss]
+
+            # loop to make matrix positive definite  
+            As = []
+            ridge_values = []
+            for k, S in enumerate(Ss):
+                S = 0.5 * (S + S.T)  # enforce symmetry
+
+                eigs = matrix.jnp.linalg.eigvalsh(S)
+                min_eig = matrix.jnp.min(eigs)
+                max_eig = matrix.jnp.max(matrix.jnp.abs(eigs))
+
+                # Safety scale
+                eps = 1e-12 * matrix.jnp.maximum(max_eig, 1.0)
+
+                # Add only what is needed to make the smallest eigenvalue positive
+                ridge = matrix.jnp.maximum(0.0, -min_eig) + eps
+
+                S_reg = S + ridge * matrix.jnp.eye(S.shape[0])
+
+                A = matrix.jnp.linalg.cholesky(S_reg)
+
+                As.append(A)
+                ridge_values.append(ridge)
+    
 
             Ds = [sPhi[:,matrix.jnp.newaxis] * S * sPhi[matrix.jnp.newaxis,:] for S in Ss]
             bs = [matrix.jnp.trace(Ds[i] @ Ds[j]) for (i,j) in self.pairs]
@@ -472,6 +496,7 @@ class OS:
 
     def gx2cdf(self, params, osxs, cutoff=1e-6, limit=100, epsabs=1e-6):
         Qmat = self.Q(params)
+
         eigx = matrix.jnp.linalg.eigh(Qmat)[0]
 
         return eig2cdf(osxs, eigx, cutoff=cutoff, limit=limit, epsabs=epsabs)
@@ -486,7 +511,7 @@ def imhof(u, x, eigs):
 
 def eig2cdf(osxs, eigs, cutoff=1e-6, limit=100, epsabs=1e-6):
     # cutoff by number of eigenvalues is more friendly to jitted imhof
-    eigs = eigs[:cutoff] if cutoff > 1 else eigs[matrix.jnp.abs(eigs) > cutoff]
+    eigs = eigs[:cutoff] if cutoff > 1 else eigs[matrix.jnp.abs(eigs) > cutoff* matrix.jnp.abs(eigs).max()]
 
     # jax.scipy.integrate is mostly not implemented. Could try quadax
     return np.array([0.5 - scipy.integrate.quad(lambda u: float(imhof(u, osx, eigs)),

--- a/tests/test_optimal.py
+++ b/tests/test_optimal.py
@@ -117,25 +117,66 @@ def test_imhof_u0_limit():
                                    rtol=1e-12, atol=0)
 
 
-def test_schur_cholesky_psd_no_ridge():
-    """schur_cholesky reproduces S = TTt - FTt.T (diag(1/P)+FFt)^-1 FTt as a
-    manifest Gram (A @ A.T), PSD by construction, matching the explicit
-    difference in float64 -- including a deliberately ill-conditioned case
-    (GW basis inside the red-noise span) where the old form needed a ridge."""
+def test_ridge_cholesky_indefinite():
+    """ridge_cholesky must return a finite Cholesky factor even when S is
+    genuinely numerically indefinite (negative eigenvalues), which is the real
+    situation for high-precision pulsars. A plain Cholesky-Schur would NaN here.
+    The raw S it returns matches the explicit difference."""
     import jax.numpy as jnp
     rng = np.random.default_rng(1)
     mF, mG = 88, 28
-    # GW design as a strict subset of the red-noise design -> S near-singular
+    # GW design as a strict subset of the red-noise design + a near-degenerate
+    # column -> S with a small *negative* eigenvalue after cancellation
     Fbig = rng.normal(size=(2000, mF))
-    Tt = jnp.asarray(Fbig[:, :mG] @ rng.normal(size=(mG, mG)))
+    M = rng.normal(size=(mG, mG)); M[:, -1] = M[:, 0] + 1e-9 * M[:, -1]
+    Tt = jnp.asarray(Fbig[:, :mG] @ M)
     Ft = jnp.asarray(Fbig)
     P = jnp.asarray(10.0 ** rng.uniform(-18, -14, size=mF))   # red-noise priors
     FFt, FTt, TTt = Ft.T @ Ft, Ft.T @ Tt, Tt.T @ Tt
 
-    A = optimal.schur_cholesky(1.0 / P, FFt, FTt, TTt)
-    S_new = np.asarray(A @ A.T)
+    A, S = optimal.ridge_cholesky(1.0 / P, FFt, FTt, TTt)
+    assert np.all(np.isfinite(np.asarray(A)))                       # no NaN from the factor
+    assert np.all(np.isfinite(np.asarray(S)))
     c = jax.scipy.linalg.cho_factor(jnp.diag(1.0 / P) + FFt)
-    S_old = np.asarray(TTt - FTt.T @ jax.scipy.linalg.cho_solve(c, FTt))
+    S_ref = np.asarray(TTt - FTt.T @ jax.scipy.linalg.cho_solve(c, FTt))
+    np.testing.assert_allclose(np.asarray(S), S_ref, rtol=0, atol=1e-9 * np.linalg.norm(S_ref))
 
-    assert np.linalg.eigvalsh(0.5 * (S_new + S_new.T)).min() > 0.0   # strictly PSD, no ridge
-    np.testing.assert_allclose(S_new, S_old, rtol=0, atol=1e-9 * np.linalg.norm(S_old))
+
+# a high-precision pulsar whose S is genuinely indefinite (min eig < 0) --
+# guards against regressions that NaN out the factorization on real data
+HARD_PSR_FILES = PSR_FILES + ["v1p1_de440_pint_bipm2019-J0437-4715.feather"]
+
+
+@pytest.fixture(scope="module")
+def os_obj_hard():
+    psrs = [ds.Pulsar.read_feather(DATA_DIR / f) for f in HARD_PSR_FILES]
+    T = ds.getspan(psrs)
+    gbl = ds.GlobalLikelihood([
+        ds.PulsarLikelihood([
+            psr.residuals,
+            ds.makenoise_measurement(psr, psr.noisedict),
+            ds.makegp_ecorr(psr, psr.noisedict),
+            ds.makegp_timing(psr, svd=True),
+            ds.makegp_fourier(psr, ds.powerlaw, 30, T=T, name='rednoise'),
+            ds.makegp_fourier(psr, ds.powerlaw, 14, T=T,
+                              common=['gw_log10_A', 'gw_gamma'], name='gw'),
+        ]) for psr in psrs])
+    return ds.OS(gbl)
+
+
+def test_Q_and_gx2cdf_finite_on_hard_pulsar(os_obj_hard):
+    """With J0437-4715 in the array (genuinely indefinite S), Q must stay
+    finite and gx2cdf must be a valid CDF (finite, monotone, in [0,1]). This
+    is the case that the NaN-prone Cholesky-Schur factorization broke."""
+    params = dict(PARAMS)
+    params['J0437-4715_rednoise_gamma'] = 3.2
+    params['J0437-4715_rednoise_log10_A'] = -14.5
+
+    Qmat = np.asarray(os_obj_hard.Q(params))
+    assert np.all(np.isfinite(Qmat)), "Q has non-finite entries (S factorization failed)"
+
+    xs = np.linspace(-2.0, 8.0, 50)
+    cdf = np.asarray(os_obj_hard.gx2cdf(params, xs, limit=1000, cutoff=1e-10, epsabs=1e-8))
+    assert np.all(np.isfinite(cdf))
+    assert cdf.min() >= -1e-8 and cdf.max() <= 1.0 + 1e-8
+    assert np.all(np.diff(cdf) >= -1e-8), "gx2cdf not monotone non-decreasing"

--- a/tests/test_optimal.py
+++ b/tests/test_optimal.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Regression tests for the optimal statistic (discovery.optimal).
+
+These pin the OS outputs on a small, fixed 3-pulsar dataset so that
+performance refactors (e.g. rewriting ``trace(A @ B)`` as ``sum(A * B)``
+in the pairwise normalization) provably do not change results.
+
+The golden values were generated from the implementation *before* the
+trace->sum refactor, with the fixed ``PARAMS`` below. ``rtol=1e-8`` is far
+looser than the ~1e-12 floating-point reassociation the refactor introduces,
+but tight enough to catch any genuine change in the computation.
+"""
+
+from pathlib import Path
+import pytest
+
+import numpy as np
+
+import jax
+jax.config.update('jax_enable_x64', True)
+
+import discovery as ds
+from discovery import optimal
+
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+PSR_FILES = [
+    "v1p1_de440_pint_bipm2019-B1855+09.feather",
+    "v1p1_de440_pint_bipm2019-J0023+0923.feather",
+    "v1p1_de440_pint_bipm2019-J0030+0451.feather",
+]
+
+# fixed parameters used to generate the golden values
+PARAMS = {
+    'B1855+09_rednoise_gamma': 3.2,   'B1855+09_rednoise_log10_A': -14.5,
+    'J0023+0923_rednoise_gamma': 3.2, 'J0023+0923_rednoise_log10_A': -14.5,
+    'J0030+0451_rednoise_gamma': 3.2, 'J0030+0451_rednoise_log10_A': -14.5,
+    'gw_gamma': 3.2,                  'gw_log10_A': -14.5,
+}
+
+# golden values (generated pre-refactor; see module docstring)
+GOLDEN_OS = {
+    'hd':     dict(os=8.3961773831359343e-29, os_sigma=3.3828949412484901e-29, snr=2.4819503794691431e+00),
+    'mono':   dict(os=1.7353193676835731e-30, os_sigma=9.2639350397105645e-30, snr=1.8731989810431465e-01),
+    'dipole': dict(os=3.7929188575728078e-29, os_sigma=1.8191630514555593e-29, snr=2.0849801531193126e+00),
+}
+GOLDEN_Q = dict(eig_min=-1.7242147637816876e-01, eig_max=2.0158562767707627e-01)
+GOLDEN_CDF_X = np.array([0.0, 1.0, 2.0])
+GOLDEN_CDF = np.array([5.1039176222643856e-01, 8.5178948105146968e-01, 9.7186069481346693e-01])
+
+RTOL = 1e-8
+
+
+@pytest.fixture(scope="module")
+def os_obj():
+    psrs = [ds.Pulsar.read_feather(DATA_DIR / f) for f in PSR_FILES]
+    T = ds.getspan(psrs)
+    gbl = ds.GlobalLikelihood([
+        ds.PulsarLikelihood([
+            psr.residuals,
+            ds.makenoise_measurement(psr, psr.noisedict),
+            ds.makegp_ecorr(psr, psr.noisedict),
+            ds.makegp_timing(psr, svd=True),
+            ds.makegp_fourier(psr, ds.powerlaw, 30, T=T, name='rednoise'),
+            ds.makegp_fourier(psr, ds.powerlaw, 14, T=T,
+                              common=['gw_log10_A', 'gw_gamma'], name='gw'),
+        ]) for psr in psrs])
+    return ds.OS(gbl)
+
+
+@pytest.mark.parametrize("orfname,orf", [
+    ('hd', optimal.hd_orfa),
+    ('mono', optimal.monopole_orfa),
+    ('dipole', optimal.dipole_orfa),
+])
+def test_os_regression(os_obj, orfname, orf):
+    """OS point estimate / sigma / snr must match pinned golden values."""
+    result = os_obj.os(PARAMS, orf)
+    golden = GOLDEN_OS[orfname]
+    for key in ('os', 'os_sigma', 'snr'):
+        np.testing.assert_allclose(float(result[key]), golden[key], rtol=RTOL,
+                                   err_msg=f"{orfname} {key} changed")
+
+
+def test_Q_eigenvalues_regression(os_obj):
+    """Eigenvalues of the OS quadratic-form matrix Q must be unchanged."""
+    eigs = np.linalg.eigvalsh(np.asarray(os_obj.Q(PARAMS)))
+    np.testing.assert_allclose(eigs.min(), GOLDEN_Q['eig_min'], rtol=RTOL)
+    np.testing.assert_allclose(eigs.max(), GOLDEN_Q['eig_max'], rtol=RTOL)
+
+
+def test_gx2cdf_regression(os_obj):
+    """quadax-based gx2cdf must match pinned golden values."""
+    cdf = np.asarray(os_obj.gx2cdf(PARAMS, GOLDEN_CDF_X))
+    np.testing.assert_allclose(cdf, GOLDEN_CDF, rtol=RTOL)
+
+
+def test_trace_sum_identity():
+    """Document the refactor's justification: trace(A @ B) == sum(A * B)
+    for symmetric A, B (so the OS pairwise normalization is unchanged)."""
+    rng = np.random.default_rng(0)
+    for m in (4, 28):
+        A = rng.normal(size=(m, m)); A = A + A.T
+        B = rng.normal(size=(m, m)); B = B + B.T
+        np.testing.assert_allclose(np.trace(A @ B), np.sum(A * B), rtol=1e-12)

--- a/tests/test_optimal.py
+++ b/tests/test_optimal.py
@@ -103,3 +103,39 @@ def test_trace_sum_identity():
         A = rng.normal(size=(m, m)); A = A + A.T
         B = rng.normal(size=(m, m)); B = B + B.T
         np.testing.assert_allclose(np.trace(A @ B), np.sum(A * B), rtol=1e-12)
+
+
+def test_imhof_u0_limit():
+    """The Imhof integrand has a removable 0/0 at u=0; it must return the
+    finite limit ½(Σλ - x), not nan (quadax may sample the endpoint)."""
+    import jax.numpy as jnp
+    eigs = jnp.array([0.20, 0.15, -0.17, -0.05, 0.02, -0.01, 1e-4, -1e-4])
+    for x in (0.0, 1.0, 2.0):
+        val = float(optimal.imhof(jnp.array(0.0), x, eigs))
+        assert np.isfinite(val)
+        np.testing.assert_allclose(val, 0.5 * (float(np.sum(np.asarray(eigs))) - x),
+                                   rtol=1e-12, atol=0)
+
+
+def test_schur_cholesky_psd_no_ridge():
+    """schur_cholesky reproduces S = TTt - FTt.T (diag(1/P)+FFt)^-1 FTt as a
+    manifest Gram (A @ A.T), PSD by construction, matching the explicit
+    difference in float64 -- including a deliberately ill-conditioned case
+    (GW basis inside the red-noise span) where the old form needed a ridge."""
+    import jax.numpy as jnp
+    rng = np.random.default_rng(1)
+    mF, mG = 88, 28
+    # GW design as a strict subset of the red-noise design -> S near-singular
+    Fbig = rng.normal(size=(2000, mF))
+    Tt = jnp.asarray(Fbig[:, :mG] @ rng.normal(size=(mG, mG)))
+    Ft = jnp.asarray(Fbig)
+    P = jnp.asarray(10.0 ** rng.uniform(-18, -14, size=mF))   # red-noise priors
+    FFt, FTt, TTt = Ft.T @ Ft, Ft.T @ Tt, Tt.T @ Tt
+
+    A = optimal.schur_cholesky(1.0 / P, FFt, FTt, TTt)
+    S_new = np.asarray(A @ A.T)
+    c = jax.scipy.linalg.cho_factor(jnp.diag(1.0 / P) + FFt)
+    S_old = np.asarray(TTt - FTt.T @ jax.scipy.linalg.cho_solve(c, FTt))
+
+    assert np.linalg.eigvalsh(0.5 * (S_new + S_new.T)).min() > 0.0   # strictly PSD, no ridge
+    np.testing.assert_allclose(S_new, S_old, rtol=0, atol=1e-9 * np.linalg.norm(S_old))


### PR DESCRIPTION
Changed the Cholesky factors used by OS. The code added a fixed diagonal regularization term before taking the Cholesky decomposition. This could still fail when the smallest eigenvalue was negative by more than the fixed ridge.

By checking the eigenvalues it then adds an ridge term that is relative on the eigenvalue such that the matrices are always positive definite, also updated the eigenvalue cutoff in `eig2cdf`. Instead of using an absolute cutoff we use a relative one.