### PR TITLE
fix: add VariableGP.params property

### DIFF
--- a/src/discovery/matrix.py
+++ b/src/discovery/matrix.py
@@ -143,6 +143,14 @@ class VariableGP:
     def __init__(self, Phi, F):
         self.Phi, self.F = Phi, F
 
+    @property
+    def params(self):
+        param_set = set()
+        for part in [self.Phi, self.F]:
+            if hasattr(part, 'params'):
+                param_set.update(part.params)
+        return sorted(param_set)
+
 
 # note that all factories that return a GlobalVariableGP should define its `index`
 # as a dictionary of component vector names to slices within the Fs matrix, which


### PR DESCRIPTION
VariableGP needs a `.params` property returning the sorted union of the parameter names of its Phi and F components, so a variable GP reports the parameters it consumes through the same interface as the other kernels.