### PR TITLE
feat: add covariance kernels for the time domain solar-wind GP

### DIFF
--- a/src/discovery/prior.py
+++ b/src/discovery/prior.py
@@ -29,6 +29,11 @@ priordict_standard = {
     "(.*_)?red_noise_log10_fb": [-9, -6],
     "(.*_)?sw_gp_log10_A": [-10, -2],
     "(.*_)?sw_gp_gamma": [0, 4],
+    # time-domain SW kernels (squared_exponential / quasi_periodic)
+    "(.*_)?sw_gp_log10_sigma": [-2, 1.3],   # log10 rms electron density (cm^-3): 0.01-20
+    "(.*_)?sw_gp_log10_ell": [1, 4],        # log10 correlation timescale (days): 10 - ~30 yr
+    "(.*_)?sw_gp_log10_Gamma": [-3, 2],     # QP periodicity weight (dimensionless)
+    "(.*_)?sw_gp_log10_p": [-2, 1.3],       # QP period (log10 years): 0.01-20
     "crn_log10_A.*": [-18, -11],
     "crn_gamma.*": [0, 7],
     "crn_log10_fb": [-9, -6],

--- a/src/discovery/signals.py
+++ b/src/discovery/signals.py
@@ -1194,3 +1194,57 @@ def makedelay(psr, delay, components=None, common=[], name='delay'):
 # use with makedelay to set residuals dynamically from arrays
 def getresiduals(y):
     return -y
+
+
+# Time-domain covariance kernels matching the NANOGrav 12.5yr CNM paper
+# (Hazboun+ 2025). Pass one as the `covariance` argument of a time-domain GP
+# such as solar.makegp_timedomain_solar_dm.
+#
+# Both kernels operate on tau given in SECONDS (matching psr.toas units),
+# while the kernel hyperparameters are in physically natural log10 units:
+#   log10_sigma  -- log10 of amplitude in seconds
+#   log10_ell    -- log10 of correlation timescale in DAYS
+#   log10_Gamma  -- log10 of periodicity weight (dimensionless, QP only)
+#   log10_p      -- log10 of period in YEARS (QP only)
+# These match the priors in Table A1 of the paper.
+def squared_exponential(tau, log10_sigma, log10_ell):
+    """Squared-exponential kernel (Eq. 4 of Hazboun+ 2025).
+
+    k_SE(tau) = sigma^2 * exp(-tau^2 / (2*ell^2))
+              + (sigma/500)^2 * delta(tau)
+
+    The (sigma/500)^2 diagonal regulariser stabilises the inversion of phi
+    for large ell, exactly as in the paper.
+    """
+    sigma  = 10.0 ** log10_sigma
+    ell_s  = (10.0 ** log10_ell) * 86400.0   # days -> seconds
+
+    smooth = (sigma ** 2) * jnp.exp(-0.5 * (tau / ell_s) ** 2)
+
+    # Kronecker delta on tau == 0 (tau is |t_k - t_l| so only diagonal hits 0).
+    diag   = (sigma / 500.0) ** 2 * (tau == 0.0)
+
+    return smooth + diag
+
+
+def quasi_periodic(tau, log10_sigma, log10_ell, log10_Gamma, log10_p):
+    """Quasi-periodic kernel (Eq. 6 of Hazboun+ 2025).
+
+    k_QP(tau) = (sigma/500)^2 * delta(tau)
+              + sigma^2 * exp(-tau^2 / (2*ell^2))
+                       * exp(-Gamma * sin^2(pi*tau/p))
+
+    Reduces to k_SE in the limit Gamma -> 0.
+    """
+    sigma  = 10.0 ** log10_sigma
+    ell_s  = (10.0 ** log10_ell) * 86400.0   # days -> seconds
+    Gamma  = 10.0 ** log10_Gamma
+    p_s    = (10.0 ** log10_p) * const.yr     # years -> seconds
+
+    se_part  = jnp.exp(-0.5 * (tau / ell_s) ** 2)
+    per_part = jnp.exp(-Gamma * jnp.sin(jnp.pi * tau / p_s) ** 2)
+
+    smooth = (sigma ** 2) * se_part * per_part
+    diag   = (sigma / 500.0) ** 2 * (tau == 0.0)
+
+    return smooth + diag

--- a/tests/test_timedomain_kernels.py
+++ b/tests/test_timedomain_kernels.py
@@ -1,0 +1,57 @@
+"""Tests for the time-domain covariance kernels and their use in the
+solar-wind time-domain GP (makegp_timedomain_solar_dm)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from discovery import signals, solar
+import discovery as ds
+
+
+DATA = Path(__file__).resolve().parent.parent / "data"
+
+
+def _tau():
+    t = np.linspace(0.0, 5 * 365.25 * 86400.0, 40)
+    return np.abs(np.subtract.outer(t, t))
+
+
+def test_squared_exponential_shape_symmetry_and_diag():
+    tau = _tau()
+    k = np.asarray(signals.squared_exponential(tau, log10_sigma=-6.0, log10_ell=2.0))
+    assert k.shape == tau.shape
+    assert np.all(np.isfinite(k))
+    assert np.allclose(k, k.T)
+    assert np.all(np.diag(k) > 0.0)
+    # off-diagonal correlation decreases with separation
+    row = k[0]
+    assert row[1] >= row[-1]
+
+
+def test_quasi_periodic_reduces_to_se_as_gamma_zero():
+    tau = _tau()
+    se = np.asarray(signals.squared_exponential(tau, -6.0, 2.0))
+    qp = np.asarray(signals.quasi_periodic(tau, -6.0, 2.0, log10_Gamma=-30.0, log10_p=0.5))
+    assert np.allclose(se, qp, rtol=1e-6, atol=1e-30)
+
+
+@pytest.mark.integration
+def test_solar_timedomain_gp_builds_and_samples():
+    f = DATA / "v1p1_de440_pint_bipm2019-J0030+0451.feather"
+    if not f.exists():
+        pytest.skip("pulsar data fixture missing")
+    psr = ds.Pulsar.read_feather(f)
+    gp = solar.makegp_timedomain_solar_dm(psr, covariance=signals.squared_exponential,
+                                          dt=14 * 86400.0, name="sw_gp")
+    model = ds.PulsarLikelihood([psr.residuals,
+                                 ds.makenoise_measurement(psr, psr.noisedict),
+                                 ds.makegp_timing(psr, svd=True),
+                                 gp])
+    params = model.logL.params
+    assert any("sw_gp_log10_sigma" in p for p in params)
+    assert any("sw_gp_log10_ell" in p for p in params)
+    # priors now live in core prior.py, so sample_uniform resolves them
+    p0 = ds.sample_uniform(params)
+    assert np.isfinite(float(model.logL(p0)))


### PR DESCRIPTION
Add squared_exponential and quasi_periodic time-domain kernels to signals.py, and their sw_gp priors (log10_sigma, log10_ell, and the QP log10_Gamma, log10_p) to prior.py. These give solar.makegp_timedomain_solar_dm a covariance function to use, so the time-domain solar-wind DM GP is usable